### PR TITLE
zig implementation: update the build script for zig 0.13+

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1,17 +1,29 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary("zig", "src/main.zig");
-    lib.setBuildMode(mode);
-    lib.install();
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
 
-    const main_tests = b.addTest("src/main.zig");
-    main_tests.setBuildMode(mode);
+    const lib_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const lib = b.addLibrary(.{
+        .linkage = .static,
+        .name = "zig",
+        .root_module = lib_mod,
+    });
+    b.installArtifact(lib);
 
-    const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    const lib_unit_tests = b.addTest(.{
+        .root_module = lib_mod,
+    });
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
 }


### PR DESCRIPTION
No changes to the code itself, but the build script requires minor changes to work with current Zig versions.