### PR TITLE
Fixes for c# implementation

### DIFF
--- a/csharp/hmac-bcrypt/HMAC_Bcrypt.cs
+++ b/csharp/hmac-bcrypt/HMAC_Bcrypt.cs
@@ -25,8 +25,8 @@ namespace hmac_bcrypt
 
             if (string.IsNullOrEmpty(salt)) {
                 settings = BCrypt.Net.BCrypt.GenerateSalt(cost);
-            } else if (settings != null) {
-                settings = settings[..29];
+            } else {
+                settings = settings![..29];
             }
 
             if (string.IsNullOrEmpty(pepper)) {

--- a/csharp/hmac-bcrypt/HMAC_Bcrypt.cs
+++ b/csharp/hmac-bcrypt/HMAC_Bcrypt.cs
@@ -33,7 +33,7 @@ namespace hmac_bcrypt
                 pepper = BCRYPT_PEPPER;
             }
 
-            HMACSHA512 hmac = new HMACSHA512(
+            using HMACSHA512 hmac = new HMACSHA512(
                 Encoding.UTF8.GetBytes(pepper)
             );
 

--- a/csharp/hmac-bcrypt/hmac-bcrypt.csproj
+++ b/csharp/hmac-bcrypt/hmac-bcrypt.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>hmac_bcrypt</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
1. `System.Security.Cryptography.HMACSHA512` implements `IDisposable`. Added `using` to ensure it is properly disposed.
2. Removed unnecessary condition on line 28. Salt comes from settings, so if salt is not null on line 26, it means we successfully parsed settings, therefore settings cannot be null. This means condition on line 28 is always true when condition on line 26 is false.
4. Updated target framework moniker to latest version (net10.0) as net6.0 is out of support.